### PR TITLE
fixed 'is_divi_enabled()' to convert theme template name to all lower…

### DIFF
--- a/inc/labs/class.llms.lab.lifti.php
+++ b/inc/labs/class.llms.lab.lifti.php
@@ -335,7 +335,7 @@ class LLMS_Lab_Lifti extends LLMS_Lab {
 	private function is_divi_enabled() {
 
 		$theme = wp_get_theme();
-		return ( 'Divi' === $theme->get_template() );
+		return ( 'divi' === strtolower( $theme->get_template() ) );
 
 	}
 


### PR DESCRIPTION
…case. The previous case sensitivity prevented lifti from working on my particular instance.