### PR TITLE
Added settings for the lessons favorite button visibility

### DIFF
--- a/.changelogs/favorites-1.yml
+++ b/.changelogs/favorites-1.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: dev
+entry: Changed priority of the action manager settings loading.

--- a/.changelogs/favorites.yml
+++ b/.changelogs/favorites.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: Added settings for the lessons favorite button visibility.

--- a/inc/labs/class.llms.lab.action.manager.php
+++ b/inc/labs/class.llms.lab.action.manager.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_Labs/Labs/Classes
  *
  * @since 1.2.0
- * @version 1.7.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -52,14 +52,14 @@ class LLMS_Lab_Action_Manager extends LLMS_Lab {
 	 * Initialize the Lab.
 	 *
 	 * @since 1.2.0
+	 * @since [version] Postpone settings creation and actions removal.
 	 *
 	 * @return void
 	 */
 	protected function init() {
 
-		$this->setup_hooks();
-
-		add_action( 'plugins_loaded', array( $this, 'remove_actions' ), 777 );
+		add_action( 'init', array( $this, 'setup_hooks' ), 11 );
+		add_action( 'init', array( $this, 'remove_actions' ), 11 );
 
 	}
 
@@ -149,6 +149,7 @@ class LLMS_Lab_Action_Manager extends LLMS_Lab {
 	 * @return void
 	 */
 	public function setup_hooks() {
+
 		$this->hooks = array(
 			array(
 				'title'   => esc_html__( 'Single Course Actions', 'lifterlms-labs' ),
@@ -163,7 +164,6 @@ class LLMS_Lab_Action_Manager extends LLMS_Lab {
 						'priority' => 30,
 						'title'    => esc_html__( 'Audio Embed', 'lifterlms-labs' ),
 					),
-
 					'lifterlms_template_single_meta_wrapper_start' => array(
 						'action'   => 'lifterlms_single_course_after_summary',
 						'priority' => 5,
@@ -232,12 +232,27 @@ class LLMS_Lab_Action_Manager extends LLMS_Lab {
 				),
 			),
 			array(
+				'title'   => esc_html__( 'Course Syllabus Actions', 'lifterlms-labs' ),
+				'actions' => array(
+					'llms_template_syllabus_favorite_lesson_preview' => array(
+						'action'   => 'llms_lesson_preview_after_title',
+						'priority' => 10,
+						'title'    => esc_html__( 'Mark Favorite / Unfavorite Lesson button on Lesson preview', 'lifterlms-labs' ),
+					),
+				),
+			),
+			array(
 				'title'   => esc_html__( 'Single Lesson Actions', 'lifterlms-labs' ),
 				'actions' => array(
 					'lifterlms_template_single_parent_course' => array(
 						'action'   => 'lifterlms_single_lesson_before_summary',
 						'priority' => 10,
 						'title'    => esc_html__( 'Back to Course Link', 'lifterlms-labs' ),
+					),
+					'llms_template_favorite' => array(
+						'action'   => 'lifterlms_single_lesson_before_summary',
+						'priority' => 10,
+						'title'    => esc_html__( 'Mark Favorite / Unfavorite Lesson button', 'lifterlms-labs' ),
 					),
 					'lifterlms_template_single_lesson_video' => array(
 						'action'   => 'lifterlms_single_lesson_before_summary',
@@ -309,6 +324,13 @@ class LLMS_Lab_Action_Manager extends LLMS_Lab {
 			unset( $this->hooks[ count( $this->hooks ) - 1 ]['actions']['lifterlms_template_loop_lesson_count'] );
 		}
 
+		// Remove setting when the favorites feature is disabled.
+		if ( ! function_exists( 'llms_is_favorites_enabled' ) || ! llms_is_favorites_enabled() ) {
+			unset(
+				$this->hooks[1], // Unset the whole Course Syllabus section since it only contains the favorite setting.
+				$this->hooks[2]['actions']['llms_template_favorite']
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
Also changed the priority when we load the action manager settings and remove/add actions.

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)/New feature (non-breaking change which adds functionality)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

